### PR TITLE
add explicit export for badge styles for vite compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     ".": "./index.js",
     "./vue": "./vue/index.js",
     "./react": "./react/index.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./badge/styles": "./badge/styles/index.js"
   },
   "engines": {
     "node": "^12.0.0 || ^14.0.0 || >=16.0.0"


### PR DESCRIPTION
similar to https://github.com/vitejs/vite/issues/1505 , in order for vite to allow importing the badge styles, the export must be explicitly defined in the package.json exports. this small tweak fixes this issue and allows this library to be used (as exemplified in the documentation) with vite as an alternative to create-react-app.